### PR TITLE
[New feature] Specify the minimum number of found files to trigger the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/files-found-trigger-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/files-found-trigger-plugin.git</developerConnection>
+    <tag>HEAD</tag>
   </scm>
 
   <build>
@@ -27,6 +28,18 @@
           <source>1.6</source>
           <target>1.6</target>
         </configuration>
+      </plugin>
+      <!-- http://stackoverflow.com/a/20657721 -->
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.4.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+            <version>1.8.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
     <pluginManagement>
@@ -52,7 +65,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore />
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -65,7 +78,7 @@
 
   <artifactId>files-found-trigger</artifactId>
   <packaging>hpi</packaging>
-  <version>1.3.2-SNAPSHOT</version>
+  <version>1.4.1-SNAPSHOT</version>
   <name>Files Found Trigger</name>
   <description>Schedules a build when certain files exist</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Files+Found+Trigger</url>

--- a/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTrigger.java
+++ b/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTrigger.java
@@ -74,6 +74,11 @@ public final class FilesFoundTrigger extends Trigger<BuildableItem> {
    * The pattern of files to ignore when searching under the base directory.
    */
   private final String ignoredFiles;
+  
+  /**
+   * The build is triggered when the number of files found is greater than or equal to this number.
+   */
+  private final String triggerNumber;
 
   /**
    * List of additional configured file patterns.
@@ -101,7 +106,7 @@ public final class FilesFoundTrigger extends Trigger<BuildableItem> {
         fixNull(configs));
     FilesFoundTriggerConfig firstConfig;
     if (configsCopy.isEmpty()) {
-      firstConfig = new FilesFoundTriggerConfig(null, "", "", "");
+      firstConfig = new FilesFoundTriggerConfig(null, "", "", "", "");
     } else {
       firstConfig = configsCopy.remove(0);
     }
@@ -109,6 +114,7 @@ public final class FilesFoundTrigger extends Trigger<BuildableItem> {
     this.directory = firstConfig.getDirectory();
     this.files = firstConfig.getFiles();
     this.ignoredFiles = firstConfig.getIgnoredFiles();
+	this.triggerNumber = firstConfig.getTriggerNumber();
     if (configsCopy.isEmpty()) {
       configsCopy = null;
     }
@@ -127,6 +133,7 @@ public final class FilesFoundTrigger extends Trigger<BuildableItem> {
     this.directory = "";
     this.files = "";
     this.ignoredFiles = "";
+	this.triggerNumber = "";
     this.additionalConfigs = null;
   }
 
@@ -139,7 +146,7 @@ public final class FilesFoundTrigger extends Trigger<BuildableItem> {
     ImmutableList.Builder<FilesFoundTriggerConfig> builder = ImmutableList
         .builder();
     builder.add(new FilesFoundTriggerConfig(node, directory, files,
-        ignoredFiles));
+        ignoredFiles, triggerNumber));
     if (additionalConfigs != null) {
       builder.addAll(additionalConfigs);
     }
@@ -153,7 +160,9 @@ public final class FilesFoundTrigger extends Trigger<BuildableItem> {
   public void run() {
     for (FilesFoundTriggerConfig config : getConfigs()) {
       FilesFoundTriggerConfig expandedConfig = config.expand();
-      if (!expandedConfig.findFiles().isEmpty()) {
+	  int numFilesFound = expandedConfig.findFiles().size();
+	  int triggerNumber = Integer.parseInt(expandedConfig.getTriggerNumber());
+      if (numFilesFound >= triggerNumber ) {
         job.scheduleBuild(0, new FilesFoundTriggerCause(expandedConfig));
         return;
       }

--- a/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTrigger.java
+++ b/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTrigger.java
@@ -106,7 +106,7 @@ public final class FilesFoundTrigger extends Trigger<BuildableItem> {
         fixNull(configs));
     FilesFoundTriggerConfig firstConfig;
     if (configsCopy.isEmpty()) {
-      firstConfig = new FilesFoundTriggerConfig(null, "", "", "", "");
+      firstConfig = new FilesFoundTriggerConfig(null, "", "", "", "1");
     } else {
       firstConfig = configsCopy.remove(0);
     }
@@ -133,7 +133,7 @@ public final class FilesFoundTrigger extends Trigger<BuildableItem> {
     this.directory = "";
     this.files = "";
     this.ignoredFiles = "";
-	this.triggerNumber = "";
+	this.triggerNumber = "1";
     this.additionalConfigs = null;
   }
 

--- a/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerCause.java
+++ b/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerCause.java
@@ -63,6 +63,11 @@ public final class FilesFoundTriggerCause extends Cause {
   private final String ignoredFiles;
 
   /**
+   * the minimum number of found files to trigger the build.
+   */
+  private final String triggerNumber;
+  
+  /**
    * Create a new {@link FilesFoundTriggerCause}.
    * 
    * @param config
@@ -73,6 +78,7 @@ public final class FilesFoundTriggerCause extends Cause {
     this.directory = config.getDirectory();
     this.files = config.getFiles();
     this.ignoredFiles = config.getIgnoredFiles();
+	this.triggerNumber = config.getTriggerNumber();
   }
 
   /**
@@ -87,6 +93,7 @@ public final class FilesFoundTriggerCause extends Cause {
     this.directory = "";
     this.files = "";
     this.ignoredFiles = "";
+	this.triggerNumber = "";
   }
 
   /**
@@ -129,6 +136,16 @@ public final class FilesFoundTriggerCause extends Cause {
   public String getIgnoredFiles() {
     return ignoredFiles;
   }
+  
+  /**
+   * Get the minimum number of found files to trigger the build.
+   * 
+   * @return the minimum number of found files to trigger the build
+   */
+  @Exported(visibility = 3)
+  public String getTriggerNumber() {
+    return triggerNumber;
+  }
 
   /**
    * {@inheritDoc}
@@ -145,7 +162,7 @@ public final class FilesFoundTriggerCause extends Cause {
    */
   @Override
   public int hashCode() {
-    return Objects.hashCode(node, directory, files, ignoredFiles);
+    return Objects.hashCode(node, directory, files, ignoredFiles, triggerNumber);
   }
 
   /**
@@ -157,7 +174,7 @@ public final class FilesFoundTriggerCause extends Cause {
       FilesFoundTriggerCause other = (FilesFoundTriggerCause) obj;
       return Objects.equal(node, other.node)
           && directory.equals(other.directory) && files.equals(other.files)
-          && ignoredFiles.equals(other.ignoredFiles);
+          && ignoredFiles.equals(other.ignoredFiles) && triggerNumber.equals(other.triggerNumber);
     }
     return false;
   }
@@ -169,7 +186,7 @@ public final class FilesFoundTriggerCause extends Cause {
   public String toString() {
     return Objects.toStringHelper(this).add("node", getNode())
         .add("directory", directory).add("files", files)
-        .add("ignoredFiles", ignoredFiles).toString();
+        .add("ignoredFiles", ignoredFiles).add("triggerNumber", triggerNumber).toString();
   }
 
   /**

--- a/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfig.java
+++ b/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfig.java
@@ -147,7 +147,7 @@ public final class FilesFoundTriggerConfig implements
     this.directory = "";
     this.files = "";
     this.ignoredFiles = "";
-	this.triggerNumber = "";
+	this.triggerNumber = "1";
   }
 
   /**

--- a/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfig.java
+++ b/src/main/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfig.java
@@ -103,6 +103,11 @@ public final class FilesFoundTriggerConfig implements
    * The pattern of files to ignore when searching under the base directory.
    */
   private final String ignoredFiles;
+  
+  /**
+   * The build is triggered when the number of files found is greater than or equal to this number.
+   */
+  private final String triggerNumber;
 
   /**
    * Create a new {@link FilesFoundTriggerConfig}.
@@ -116,14 +121,18 @@ public final class FilesFoundTriggerConfig implements
    * @param ignoredFiles
    *          the pattern of files to ignore when searching under the base
    *          directory
+   * @param triggerNumber
+   *          the build is triggered when the number of files found is 
+   *          greater than or equal to this number.
    */
   @DataBoundConstructor
   public FilesFoundTriggerConfig(String node, String directory, String files,
-      String ignoredFiles) {
+      String ignoredFiles, String triggerNumber) {
     this.node = fixNode(node);
     this.directory = fixNull(directory).trim();
     this.files = fixNull(files).trim();
     this.ignoredFiles = fixNull(ignoredFiles).trim();
+	this.triggerNumber = fixNull(triggerNumber).trim();
   }
 
   /**
@@ -138,6 +147,7 @@ public final class FilesFoundTriggerConfig implements
     this.directory = "";
     this.files = "";
     this.ignoredFiles = "";
+	this.triggerNumber = "";
   }
 
   /**
@@ -184,6 +194,15 @@ public final class FilesFoundTriggerConfig implements
   public String getIgnoredFiles() {
     return ignoredFiles;
   }
+  
+  /**
+   * Get the minimum number of found files to trigger the build.
+   * 
+   * @return the minimum number of files to trigger the build
+   */
+  public String getTriggerNumber() {
+	return triggerNumber;
+  }
 
   /**
    * {@inheritDoc}
@@ -192,7 +211,8 @@ public final class FilesFoundTriggerConfig implements
   public String toString() {
     return Objects.toStringHelper(this).add("node", node)
         .add("directory", directory).add("files", files)
-        .add("ignoredFiles", ignoredFiles).toString();
+        .add("ignoredFiles", ignoredFiles)
+		.add("triggerNumber", triggerNumber).toString();
   }
 
   /**
@@ -220,9 +240,10 @@ public final class FilesFoundTriggerConfig implements
     String expDirectory = vars.expand(directory);
     String expFiles = vars.expand(files);
     String expIgnoredFiles = vars.expand(ignoredFiles);
-
+	String expTriggerNumber = vars.expand(triggerNumber);
+	
     return new FilesFoundTriggerConfig(expNode, expDirectory, expFiles,
-        expIgnoredFiles);
+        expIgnoredFiles, expTriggerNumber);
   }
 
   /**
@@ -287,7 +308,9 @@ public final class FilesFoundTriggerConfig implements
      *          the pattern of files to locate under the base directory
      * @param ignoredFiles
      *          the pattern of files to ignore when searching under the base
-     *          directory
+	 *          directory
+	 * @param triggerNumber
+	 *          the minimum number of found files to trigger the build          
      * @return the result
      * @throws IOException
      * @throws InterruptedException
@@ -296,11 +319,12 @@ public final class FilesFoundTriggerConfig implements
         @QueryParameter("node") final String node,
         @QueryParameter("directory") final String directory,
         @QueryParameter("files") final String files,
-        @QueryParameter("ignoredFiles") final String ignoredFiles)
+        @QueryParameter("ignoredFiles") final String ignoredFiles,
+		@QueryParameter("triggerNumber") final String triggerNumber)
         throws IOException, InterruptedException {
 
       FilesFoundTriggerConfig config = new FilesFoundTriggerConfig(node,
-          directory, files, ignoredFiles);
+          directory, files, ignoredFiles, triggerNumber);
       return FileSearch.perform(config.expand()).formValidation;
     }
 

--- a/src/main/resources/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfig/config.jelly
@@ -39,6 +39,9 @@ THE SOFTWARE.
   <f:entry title="${%Files to ignore}" field="ignoredFiles">
     <f:textbox value="${it.ignoredFiles}"/>
   </f:entry>
+  <f:entry title="${%Number of files found to trigger}" field="triggerNumber">
+    <f:textbox default="1" value="${it.triggerNumber}"/>
+  </f:entry>
   <f:validateButton
       title="${%Test}" progress="${%Testing...}"
       method="testConfiguration" with="node,directory,files,ignoredFiles"/>

--- a/src/main/resources/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfig/help-triggerNumber.html
+++ b/src/main/resources/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfig/help-triggerNumber.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2011 Steven G. Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+The build is triggered when the number of files found is greater than or equal to this number.
+<p>
+Environment variable during the build: filesfound_setting_ignoredfiles

--- a/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundEnvironmentContributorTest.java
+++ b/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundEnvironmentContributorTest.java
@@ -27,6 +27,7 @@ import static hudson.plugins.filesfoundtrigger.Support.DIRECTORY;
 import static hudson.plugins.filesfoundtrigger.Support.FILES;
 import static hudson.plugins.filesfoundtrigger.Support.IGNORED_FILES;
 import static hudson.plugins.filesfoundtrigger.Support.MASTER_NODE;
+import static hudson.plugins.filesfoundtrigger.Support.TRIGGER_NUMBER;
 import static hudson.plugins.filesfoundtrigger.Support.cause;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -70,7 +71,7 @@ public class FilesFoundEnvironmentContributorTest {
     expected.put("filesfound_setting_ignoredfiles", IGNORED_FILES);
 
     FilesFoundTriggerCause cause = cause(MASTER_NODE, DIRECTORY, FILES,
-        IGNORED_FILES);
+        IGNORED_FILES, TRIGGER_NUMBER);
     when(run.getCause(FilesFoundTriggerCause.class)).thenReturn(cause);
     assertThat(contributeEnvVars(), is(expected));
   }

--- a/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerCauseTest.java
+++ b/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerCauseTest.java
@@ -31,6 +31,7 @@ import static hudson.plugins.filesfoundtrigger.Support.FILES;
 import static hudson.plugins.filesfoundtrigger.Support.IGNORED_FILES;
 import static hudson.plugins.filesfoundtrigger.Support.MASTER_NODE;
 import static hudson.plugins.filesfoundtrigger.Support.SLAVE_NODE;
+import static hudson.plugins.filesfoundtrigger.Support.TRIGGER_NUMBER;
 import static hudson.plugins.filesfoundtrigger.Support.cause;
 import static hudson.plugins.filesfoundtrigger.Support.fromXml;
 import static hudson.plugins.filesfoundtrigger.Support.toXml;
@@ -71,7 +72,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getNodeMaster() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).getNode(),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).getNode(),
         is(MASTER_NODE));
   }
 
@@ -79,7 +80,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getNodeSlave() {
-    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES).getNode(),
+    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).getNode(),
         is(SLAVE_NODE));
   }
 
@@ -87,7 +88,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getDirectory() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES)
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)
         .getDirectory(), is(DIRECTORY));
   }
 
@@ -95,7 +96,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getFiles() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).getFiles(),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).getFiles(),
         is(FILES));
   }
 
@@ -103,7 +104,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getIgnoredFiles() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES)
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)
         .getIgnoredFiles(), is(IGNORED_FILES));
   }
 
@@ -111,7 +112,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getIgnoredFilesNotSpecified() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, "").getIgnoredFiles(),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).getIgnoredFiles(),
         is(""));
   }
 
@@ -119,7 +120,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getShortDescriptionMaster() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, "").getShortDescription(),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).getShortDescription(),
         is(Messages.Cause(MASTER_NODE, DIRECTORY, FILES)));
   }
 
@@ -127,7 +128,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getShortDescriptionSlave() {
-    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, "").getShortDescription(),
+    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).getShortDescription(),
         is(Messages.Cause(SLAVE_NODE, DIRECTORY, FILES)));
   }
 
@@ -135,7 +136,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getShortDescriptionMasterWithIgnoredFiles() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES)
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)
         .getShortDescription(), is(Messages.CauseWithIgnoredFiles(MASTER_NODE,
         DIRECTORY, FILES, IGNORED_FILES)));
   }
@@ -144,7 +145,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void getShortDescriptionSlaveWithIgnoredFiles() {
-    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES)
+    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)
         .getShortDescription(), is(Messages.CauseWithIgnoredFiles(SLAVE_NODE,
         DIRECTORY, FILES, IGNORED_FILES)));
   }
@@ -153,39 +154,39 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void hashCodeMaster() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, "").hashCode(),
-        is(cause(MASTER_NODE, DIRECTORY, FILES, "").hashCode()));
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).hashCode(),
+        is(cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).hashCode()));
   }
 
   /**
    */
   @Test
   public void hashCodeSlave() {
-    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, "").hashCode(),
-        is(cause(SLAVE_NODE, DIRECTORY, FILES, "").hashCode()));
+    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).hashCode(),
+        is(cause(SLAVE_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).hashCode()));
   }
 
   /**
    */
   @Test
   public void hashCodeMasterWithIgnoredFiles() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).hashCode(),
-        is(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).hashCode()));
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).hashCode(),
+        is(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).hashCode()));
   }
 
   /**
    */
   @Test
   public void hashCodeSlaveWithIgnoredFiles() {
-    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES).hashCode(),
-        is(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES).hashCode()));
+    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).hashCode(),
+        is(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).hashCode()));
   }
 
   /**
    */
   @Test
   public void equalsNull() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER),
         not(equalTo(null)));
   }
 
@@ -194,7 +195,7 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void equalsObjectOfDifferentClass() {
     assertThat(
-        cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES)
+        cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)
             .equals(new Object()), is(false));
   }
 
@@ -203,8 +204,8 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void equalsNodeDiffers() {
     assertThat(
-        cause(MASTER_NODE, DIRECTORY, FILES, "").equals(
-            cause(SLAVE_NODE, DIRECTORY, FILES, "")), is(false));
+        cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).equals(
+            cause(SLAVE_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER)), is(false));
   }
 
   /**
@@ -212,8 +213,8 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void equalsDirectoryDiffers() {
     assertThat(
-        cause(MASTER_NODE, DIRECTORY, FILES, "").equals(
-            cause(MASTER_NODE, ALTERNATE_DIRECTORY, FILES, "")), is(false));
+        cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).equals(
+            cause(MASTER_NODE, ALTERNATE_DIRECTORY, FILES, "", TRIGGER_NUMBER)), is(false));
   }
 
   /**
@@ -221,8 +222,8 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void equalsFilesDiffers() {
     assertThat(
-        cause(MASTER_NODE, DIRECTORY, FILES, "").equals(
-            cause(MASTER_NODE, DIRECTORY, ALTERNATE_FILES, "")), is(false));
+        cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).equals(
+            cause(MASTER_NODE, DIRECTORY, ALTERNATE_FILES, "", TRIGGER_NUMBER)), is(false));
   }
 
   /**
@@ -230,8 +231,8 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void equalsIgnoredFilesDiffers() {
     assertThat(
-        cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).equals(
-            cause(MASTER_NODE, DIRECTORY, FILES, ALTERNATE_IGNORED_FILES)),
+        cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).equals(
+            cause(MASTER_NODE, DIRECTORY, FILES, ALTERNATE_IGNORED_FILES, TRIGGER_NUMBER)),
         is(false));
   }
 
@@ -240,8 +241,8 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void equalsObjectsAreEqual() {
     assertThat(
-        cause(MASTER_NODE, DIRECTORY, FILES, "").equals(
-            cause(MASTER_NODE, DIRECTORY, FILES, "")), is(true));
+        cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER).equals(
+            cause(MASTER_NODE, DIRECTORY, FILES, "", TRIGGER_NUMBER)), is(true));
   }
 
   /**
@@ -249,15 +250,15 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void equalsObjectsAreEqualWithIgnoredFiles() {
     assertThat(
-        cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).equals(
-            cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES)), is(true));
+        cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).equals(
+            cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)), is(true));
   }
 
   /**
    */
   @Test
   public void toStringContainsNodeMaster() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(MASTER_NODE));
   }
 
@@ -265,7 +266,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void toStringContainsNodeSlave() {
-    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(SLAVE_NODE));
   }
 
@@ -273,7 +274,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void toStringContainsDirectory() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(DIRECTORY));
   }
 
@@ -281,7 +282,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void toStringContainsFiles() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(FILES));
   }
 
@@ -289,7 +290,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void toStringContainsIgnoredFiles() {
-    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(IGNORED_FILES));
   }
 
@@ -297,7 +298,7 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void writeToXmlMaster() {
-    String xml = toXml(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES));
+    String xml = toXml(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(xml,
         is(String.format(XML_MASTER, DIRECTORY, FILES, IGNORED_FILES)));
   }
@@ -306,9 +307,9 @@ public class FilesFoundTriggerCauseTest {
    */
   @Test
   public void writeToXmlSlave() {
-    String xml = toXml(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES));
+    String xml = toXml(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(xml, is(String.format(XML_SLAVE, SLAVE_NODE, DIRECTORY, FILES,
-        IGNORED_FILES)));
+        IGNORED_FILES, TRIGGER_NUMBER)));
   }
 
   /**
@@ -318,7 +319,7 @@ public class FilesFoundTriggerCauseTest {
     FilesFoundTriggerCause cause = fromXml(String.format(XML_MASTER, DIRECTORY,
         FILES, IGNORED_FILES));
     assertThat(String.valueOf(cause),
-        is(String.valueOf(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES))));
+        is(String.valueOf(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER))));
   }
 
   /**
@@ -328,7 +329,7 @@ public class FilesFoundTriggerCauseTest {
     FilesFoundTriggerCause cause = fromXml(String.format(XML_SLAVE, SLAVE_NODE,
         DIRECTORY, FILES, IGNORED_FILES));
     assertThat(String.valueOf(cause),
-        is(String.valueOf(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES))));
+        is(String.valueOf(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER))));
   }
 
   /**
@@ -338,6 +339,6 @@ public class FilesFoundTriggerCauseTest {
     FilesFoundTriggerCause cause = fromXml(String
         .format("<hudson.plugins.filesfoundtrigger.FilesFoundTriggerCause>\n"
             + "</hudson.plugins.filesfoundtrigger.FilesFoundTriggerCause>"));
-    assertThat(String.valueOf(cause), is(String.valueOf(cause("", "", "", ""))));
+    assertThat(String.valueOf(cause), is(String.valueOf(cause("", "", "", "", TRIGGER_NUMBER))));
   }
 }

--- a/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerCauseTest.java
+++ b/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerCauseTest.java
@@ -57,6 +57,7 @@ public class FilesFoundTriggerCauseTest {
       + "  <directory>%s</directory>\n"
       + "  <files>%s</files>\n"
       + "  <ignoredFiles>%s</ignoredFiles>\n"
+      + "  <triggerNumber>%s</triggerNumber>\n"
       + "</hudson.plugins.filesfoundtrigger.FilesFoundTriggerCause>";
 
   /**
@@ -66,6 +67,7 @@ public class FilesFoundTriggerCauseTest {
       + "  <directory>%s</directory>\n"
       + "  <files>%s</files>\n"
       + "  <ignoredFiles>%s</ignoredFiles>\n"
+      + "  <triggerNumber>%s</triggerNumber>\n"
       + "</hudson.plugins.filesfoundtrigger.FilesFoundTriggerCause>";
 
   /**
@@ -300,7 +302,7 @@ public class FilesFoundTriggerCauseTest {
   public void writeToXmlMaster() {
     String xml = toXml(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(xml,
-        is(String.format(XML_MASTER, DIRECTORY, FILES, IGNORED_FILES)));
+        is(String.format(XML_MASTER, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)));
   }
 
   /**
@@ -317,7 +319,7 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void readFromXmlMaster() {
     FilesFoundTriggerCause cause = fromXml(String.format(XML_MASTER, DIRECTORY,
-        FILES, IGNORED_FILES));
+        FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(String.valueOf(cause),
         is(String.valueOf(cause(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER))));
   }
@@ -327,7 +329,7 @@ public class FilesFoundTriggerCauseTest {
   @Test
   public void readFromXmlSlave() {
     FilesFoundTriggerCause cause = fromXml(String.format(XML_SLAVE, SLAVE_NODE,
-        DIRECTORY, FILES, IGNORED_FILES));
+        DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(String.valueOf(cause),
         is(String.valueOf(cause(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER))));
   }
@@ -339,6 +341,6 @@ public class FilesFoundTriggerCauseTest {
     FilesFoundTriggerCause cause = fromXml(String
         .format("<hudson.plugins.filesfoundtrigger.FilesFoundTriggerCause>\n"
             + "</hudson.plugins.filesfoundtrigger.FilesFoundTriggerCause>"));
-    assertThat(String.valueOf(cause), is(String.valueOf(cause("", "", "", "", TRIGGER_NUMBER))));
+    assertThat(String.valueOf(cause), is(String.valueOf(cause("", "", "", "", ""))));
   }
 }

--- a/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerConfigTest.java
@@ -28,6 +28,7 @@ import static hudson.plugins.filesfoundtrigger.Support.FILES;
 import static hudson.plugins.filesfoundtrigger.Support.IGNORED_FILES;
 import static hudson.plugins.filesfoundtrigger.Support.MASTER_NODE;
 import static hudson.plugins.filesfoundtrigger.Support.SLAVE_NODE;
+import static hudson.plugins.filesfoundtrigger.Support.TRIGGER_NUMBER;
 import static hudson.plugins.filesfoundtrigger.Support.config;
 import static hudson.util.FormValidation.Kind.ERROR;
 import static hudson.util.FormValidation.Kind.OK;
@@ -100,7 +101,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void getNodeMaster() {
-    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).getNode(),
+    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).getNode(),
         is(nullValue()));
   }
 
@@ -108,7 +109,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void getNodeSlave() {
-    assertThat(config(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES).getNode(),
+    assertThat(config(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).getNode(),
         is(SLAVE_NODE));
   }
 
@@ -116,7 +117,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void getDirectory() {
-    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES)
+    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)
         .getDirectory(), is(DIRECTORY));
   }
 
@@ -125,7 +126,7 @@ public class FilesFoundTriggerConfigTest {
   @Test
   public void getDirectoryTrimmed() {
     assertThat(
-        config(MASTER_NODE, "  " + DIRECTORY + "  ", FILES, IGNORED_FILES)
+        config(MASTER_NODE, "  " + DIRECTORY + "  ", FILES, IGNORED_FILES, TRIGGER_NUMBER)
             .getDirectory(), is(DIRECTORY));
   }
 
@@ -133,7 +134,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void getFiles() {
-    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).getFiles(),
+    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).getFiles(),
         is(FILES));
   }
 
@@ -142,7 +143,7 @@ public class FilesFoundTriggerConfigTest {
   @Test
   public void getFilesTrimmed() {
     assertThat(
-        config(MASTER_NODE, DIRECTORY, "  " + FILES + "  ", IGNORED_FILES)
+        config(MASTER_NODE, DIRECTORY, "  " + FILES + "  ", IGNORED_FILES, TRIGGER_NUMBER)
             .getFiles(), is(FILES));
   }
 
@@ -150,7 +151,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void getIgnoredFiles() {
-    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES)
+    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)
         .getIgnoredFiles(), is(IGNORED_FILES));
   }
 
@@ -159,7 +160,7 @@ public class FilesFoundTriggerConfigTest {
   @Test
   public void getIgnoredFilesTrimmed() {
     assertThat(
-        config(MASTER_NODE, DIRECTORY, FILES, "  " + IGNORED_FILES + "  ")
+        config(MASTER_NODE, DIRECTORY, FILES, "  " + IGNORED_FILES + "  ", TRIGGER_NUMBER)
             .getIgnoredFiles(), is(IGNORED_FILES));
   }
 
@@ -168,7 +169,7 @@ public class FilesFoundTriggerConfigTest {
   @Test
   public void findFilesDirectoryNotSpecified() {
     FilesFoundTriggerConfig config = config(MASTER_NODE, "", FILES,
-        IGNORED_FILES);
+        IGNORED_FILES, TRIGGER_NUMBER);
     assertThat(config.findFiles(), is(Collections.<String> emptyList()));
   }
 
@@ -178,7 +179,7 @@ public class FilesFoundTriggerConfigTest {
   public void findFilesDirectoryNotFound() {
     File nonExistentDirectory = new File(folder.getRoot(), "nonexistent");
     FilesFoundTriggerConfig config = config(MASTER_NODE,
-        nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES);
+        nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER);
     assertThat(config.findFiles(), is(Collections.<String> emptyList()));
   }
 
@@ -187,7 +188,7 @@ public class FilesFoundTriggerConfigTest {
   @Test
   public void findFilesFilesNotSpecified() {
     FilesFoundTriggerConfig config = config(MASTER_NODE, folder.getRoot()
-        .getAbsolutePath(), "", IGNORED_FILES);
+        .getAbsolutePath(), "", IGNORED_FILES, TRIGGER_NUMBER);
     assertThat(config.findFiles(), is(Collections.<String> emptyList()));
   }
 
@@ -196,7 +197,7 @@ public class FilesFoundTriggerConfigTest {
   @Test
   public void findFilesNoFiles() {
     FilesFoundTriggerConfig config = config(MASTER_NODE, folder.getRoot()
-        .getAbsolutePath(), FILES, IGNORED_FILES);
+        .getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER);
     assertThat(config.findFiles(), is(Collections.<String> emptyList()));
   }
 
@@ -208,7 +209,7 @@ public class FilesFoundTriggerConfigTest {
   public void findFilesOneFile() throws IOException {
     folder.newFile("test");
     FilesFoundTriggerConfig config = config(MASTER_NODE, folder.getRoot()
-        .getAbsolutePath(), FILES, IGNORED_FILES);
+        .getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER);
     assertThat(config.findFiles(), is(Collections.singletonList("test")));
   }
 
@@ -221,7 +222,7 @@ public class FilesFoundTriggerConfigTest {
     folder.newFile("test");
     folder.newFile("test2");
     FilesFoundTriggerConfig config = config(MASTER_NODE, folder.getRoot()
-        .getAbsolutePath(), FILES, IGNORED_FILES);
+        .getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER);
     assertThat(config.findFiles(), is(Arrays.asList("test", "test2")));
   }
 
@@ -233,7 +234,7 @@ public class FilesFoundTriggerConfigTest {
   public void findFilesNoUnignoredFiles() throws IOException {
     folder.newFile("test");
     FilesFoundTriggerConfig config = config(MASTER_NODE, folder.getRoot()
-        .getAbsolutePath(), FILES, "**");
+        .getAbsolutePath(), FILES, "**", TRIGGER_NUMBER);
     assertThat(config.findFiles(), is(Collections.<String> emptyList()));
   }
 
@@ -241,7 +242,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void toStringContainsNode() {
-    assertThat(config(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(config(SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(SLAVE_NODE));
   }
 
@@ -249,7 +250,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void toStringContainsDirectory() {
-    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(DIRECTORY));
   }
 
@@ -257,7 +258,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void toStringContainsFiles() {
-    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(FILES));
   }
 
@@ -265,7 +266,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void toStringContainsIgnoredFiles() {
-    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES).toString(),
+    assertThat(config(MASTER_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER).toString(),
         containsString(IGNORED_FILES));
   }
 
@@ -281,7 +282,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void doTestConfigurationDirectoryNotSpecified() {
-    assertThat(validate("", FILES, IGNORED_FILES),
+    assertThat(validate("", FILES, IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(ERROR, Messages.DirectoryNotSpecified())));
   }
 
@@ -289,7 +290,7 @@ public class FilesFoundTriggerConfigTest {
    */
   @Test
   public void doTestConfigurationFilesNotSpecified() {
-    assertThat(validate(DIRECTORY, "", IGNORED_FILES),
+    assertThat(validate(DIRECTORY, "", IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(ERROR, Messages.FilesNotSpecified())));
   }
 
@@ -299,7 +300,7 @@ public class FilesFoundTriggerConfigTest {
   public void doTestConfigurationDirectoryNotFound() {
     File nonExistentDirectory = new File(folder.getRoot(), "nonexistent");
     assertThat(
-        validate(nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES),
+        validate(nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(WARNING, Messages.DirectoryNotFound(userName))));
   }
 
@@ -310,7 +311,7 @@ public class FilesFoundTriggerConfigTest {
     defineGlobalProperty("property", "nonexistent");
     File nonExistentDirectory = new File(folder.getRoot(), "$property");
     assertThat(
-        validate(nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES),
+        validate(nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(WARNING, Messages.DirectoryNotFound(userName))));
   }
 
@@ -320,7 +321,7 @@ public class FilesFoundTriggerConfigTest {
   public void doTestConfigurationDirectoryNotFoundWithUnrecognisedProperty() {
     File nonExistentDirectory = new File(folder.getRoot(), "$nonexistent");
     assertThat(
-        validate(nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES),
+        validate(nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(WARNING, Messages.DirectoryNotFound(userName))));
   }
 
@@ -331,7 +332,7 @@ public class FilesFoundTriggerConfigTest {
     defineGlobalProperty("property", "");
     File nonExistentDirectory = new File(folder.getRoot(), "$property");
     assertThat(
-        validate(nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES),
+        validate(nonExistentDirectory.getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(WARNING, Messages.DirectoryNotFound(userName))));
   }
 
@@ -340,7 +341,7 @@ public class FilesFoundTriggerConfigTest {
   @Test
   public void doTestConfigurationNoFilesFound() {
     assertThat(
-        validate(folder.getRoot().getAbsolutePath(), FILES, IGNORED_FILES),
+        validate(folder.getRoot().getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(OK, Messages.NoFilesFound())));
   }
 
@@ -353,7 +354,7 @@ public class FilesFoundTriggerConfigTest {
     folder.newFile("test");
     defineGlobalProperty("property", "test");
     assertThat(
-        validate(folder.getRoot().getAbsolutePath(), "$property", IGNORED_FILES),
+        validate(folder.getRoot().getAbsolutePath(), "$property", IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(OK, Messages.SingleFileFound("test"))));
   }
 
@@ -365,7 +366,7 @@ public class FilesFoundTriggerConfigTest {
   public void doTestConfigurationOneFileFound() throws IOException {
     folder.newFile("test");
     assertThat(
-        validate(folder.getRoot().getAbsolutePath(), FILES, IGNORED_FILES),
+        validate(folder.getRoot().getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(OK, Messages.SingleFileFound("test"))));
   }
 
@@ -379,7 +380,7 @@ public class FilesFoundTriggerConfigTest {
     folder.newFile("test");
     folder.newFile("test2");
     assertThat(
-        validate(folder.getRoot().getAbsolutePath(), FILES, IGNORED_FILES),
+        validate(folder.getRoot().getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(OK, Messages.MultipleFilesFound(2))));
   }
 
@@ -392,7 +393,7 @@ public class FilesFoundTriggerConfigTest {
     folder.newFile("test");
     defineGlobalProperty("property", "test");
     assertThat(
-        validate(folder.getRoot().getAbsolutePath(), "$property", IGNORED_FILES),
+        validate(folder.getRoot().getAbsolutePath(), "$property", IGNORED_FILES, TRIGGER_NUMBER),
         is(validation(OK, Messages.SingleFileFound("test"))));
   }
 
@@ -405,11 +406,11 @@ public class FilesFoundTriggerConfigTest {
   }
 
   private static Validation validate(String directory, String files,
-      String ignoredFiles) {
+      String ignoredFiles, String triggerNumber) {
     FormValidation formValidation;
     try {
       formValidation = new FilesFoundTriggerConfig.DescriptorImpl()
-          .doTestConfiguration(MASTER_NODE, directory, files, ignoredFiles);
+          .doTestConfiguration(MASTER_NODE, directory, files, ignoredFiles, triggerNumber);
     } catch (IOException e) {
       throw new RuntimeException(e);
     } catch (InterruptedException e) {

--- a/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerTest.java
+++ b/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerTest.java
@@ -89,6 +89,7 @@ public class FilesFoundTriggerTest {
       + "  <directory>%s</directory>\n"
       + "  <files>%s</files>\n"
       + "  <ignoredFiles>%s</ignoredFiles>\n"
+      + "  <triggerNumber>%s</triggerNumber>\n"
       + "</hudson.plugins.filesfoundtrigger.FilesFoundTrigger>";
 
   /**
@@ -99,6 +100,7 @@ public class FilesFoundTriggerTest {
       + "  <directory>%s</directory>\n"
       + "  <files>%s</files>\n"
       + "  <ignoredFiles>%s</ignoredFiles>\n"
+      + "  <triggerNumber>%s</triggerNumber>\n"
       + "</hudson.plugins.filesfoundtrigger.FilesFoundTrigger>";
 
   /**
@@ -108,11 +110,13 @@ public class FilesFoundTriggerTest {
       + "  <directory>%s</directory>\n"
       + "  <files>%s</files>\n"
       + "  <ignoredFiles>%s</ignoredFiles>\n"
+      + "  <triggerNumber>%s</triggerNumber>\n"
       + "  <additionalConfigs>\n"
       + "    <hudson.plugins.filesfoundtrigger.FilesFoundTriggerConfig>\n"
       + "      <directory>%s</directory>\n"
       + "      <files>%s</files>\n"
       + "      <ignoredFiles>%s</ignoredFiles>\n"
+      + "      <triggerNumber>%s</triggerNumber>\n"
       + "    </hudson.plugins.filesfoundtrigger.FilesFoundTriggerConfig>\n"
       + "  </additionalConfigs>\n"
       + "</hudson.plugins.filesfoundtrigger.FilesFoundTrigger>";
@@ -125,12 +129,14 @@ public class FilesFoundTriggerTest {
       + "  <directory>%s</directory>\n"
       + "  <files>%s</files>\n"
       + "  <ignoredFiles>%s</ignoredFiles>\n"
+      + "  <triggerNumber>%s</triggerNumber>\n"
       + "  <additionalConfigs>\n"
       + "    <hudson.plugins.filesfoundtrigger.FilesFoundTriggerConfig>\n"
       + "      <node>%s</node>\n"
       + "      <directory>%s</directory>\n"
       + "      <files>%s</files>\n"
       + "      <ignoredFiles>%s</ignoredFiles>\n"
+      + "      <triggerNumber>%s</triggerNumber>\n"
       + "    </hudson.plugins.filesfoundtrigger.FilesFoundTriggerConfig>\n"
       + "  </additionalConfigs>\n"
       + "</hudson.plugins.filesfoundtrigger.FilesFoundTrigger>";
@@ -303,7 +309,7 @@ public class FilesFoundTriggerTest {
   public void writeToXmlSlaveWithAdditionalConfigs() {
     String xml = toXml(trigger(SPEC, slaveConfig(), slaveConfig()));
     assertThat(xml, is(String.format(XML_SLAVE_ADDITIONAL_CONFIGS, SPEC,
-        SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, SLAVE_NODE, DIRECTORY,
+        SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER, SLAVE_NODE, DIRECTORY,
         FILES, IGNORED_FILES, TRIGGER_NUMBER)));
   }
 
@@ -312,7 +318,7 @@ public class FilesFoundTriggerTest {
   @Test
   public void readFromXmlMaster() {
     FilesFoundTrigger trigger = fromXml(String.format(XML_MASTER, SPEC,
-        DIRECTORY, FILES, IGNORED_FILES));
+        DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(String.valueOf(trigger),
         is(String.valueOf(trigger(SPEC, masterConfig()))));
     assertThat("tabs", getTabs(trigger), not(nullValue()));
@@ -334,8 +340,8 @@ public class FilesFoundTriggerTest {
   @Test
   public void readFromXmlMasterWithAdditionalConfigs() {
     FilesFoundTrigger trigger = fromXml(String.format(
-        XML_MASTER_ADDITIONAL_CONFIGS, SPEC, DIRECTORY, FILES, IGNORED_FILES,
-        DIRECTORY, FILES, IGNORED_FILES));
+        XML_MASTER_ADDITIONAL_CONFIGS, SPEC, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER, 
+        DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(String.valueOf(trigger),
         is(String.valueOf(trigger(SPEC, masterConfig(), masterConfig()))));
     assertThat("tabs", getTabs(trigger), not(nullValue()));
@@ -347,7 +353,7 @@ public class FilesFoundTriggerTest {
   public void readFromXmlSlaveWithAdditionalConfigs() {
     FilesFoundTrigger trigger = fromXml(String.format(
         XML_SLAVE_ADDITIONAL_CONFIGS, SPEC, SLAVE_NODE, DIRECTORY, FILES,
-        IGNORED_FILES, SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES));
+        IGNORED_FILES, TRIGGER_NUMBER, SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(String.valueOf(trigger),
         is(String.valueOf(trigger(SPEC, slaveConfig(), slaveConfig()))));
     assertThat("tabs", getTabs(trigger), not(nullValue()));
@@ -362,7 +368,7 @@ public class FilesFoundTriggerTest {
             + "  <spec>%s</spec>\n"
             + "</hudson.plugins.filesfoundtrigger.FilesFoundTrigger>", SPEC));
     assertThat(String.valueOf(trigger), is(String.valueOf(trigger(SPEC,
-        new FilesFoundTriggerConfig("", "", "", "", "")))));
+        new FilesFoundTriggerConfig("", "", "", "", "1")))));
     assertThat("tabs", getTabs(trigger), not(nullValue()));
   }
 

--- a/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerTest.java
+++ b/src/test/java/hudson/plugins/filesfoundtrigger/FilesFoundTriggerTest.java
@@ -28,6 +28,7 @@ import static hudson.plugins.filesfoundtrigger.Support.FILES;
 import static hudson.plugins.filesfoundtrigger.Support.IGNORED_FILES;
 import static hudson.plugins.filesfoundtrigger.Support.MASTER_NODE;
 import static hudson.plugins.filesfoundtrigger.Support.SLAVE_NODE;
+import static hudson.plugins.filesfoundtrigger.Support.TRIGGER_NUMBER;
 import static hudson.plugins.filesfoundtrigger.Support.SPEC;
 import static hudson.plugins.filesfoundtrigger.Support.emptyConfig;
 import static hudson.plugins.filesfoundtrigger.Support.fromXml;
@@ -223,8 +224,9 @@ public class FilesFoundTriggerTest {
     defineGlobalProperty("directory", expandedConfig.getDirectory());
     defineGlobalProperty("files", expandedConfig.getFiles());
     defineGlobalProperty("ignoredFiles", expandedConfig.getIgnoredFiles());
+	defineGlobalProperty("triggerNumber", expandedConfig.getTriggerNumber());
     FilesFoundTriggerConfig config = new FilesFoundTriggerConfig("$node",
-        "$directory", "$files", "$ignoredFiles");
+        "$directory", "$files", "$ignoredFiles", "$triggerNumber");
     FilesFoundTrigger trigger = trigger(SPEC, config);
     trigger.start(job, true);
     trigger.run();
@@ -274,7 +276,7 @@ public class FilesFoundTriggerTest {
   public void writeToXmlMaster() {
     String xml = toXml(trigger(SPEC, masterConfig()));
     assertThat(xml,
-        is(String.format(XML_MASTER, SPEC, DIRECTORY, FILES, IGNORED_FILES)));
+        is(String.format(XML_MASTER, SPEC, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)));
   }
 
   /**
@@ -283,7 +285,7 @@ public class FilesFoundTriggerTest {
   public void writeToXmlSlave() {
     String xml = toXml(trigger(SPEC, slaveConfig()));
     assertThat(xml, is(String.format(XML_SLAVE, SPEC, SLAVE_NODE, DIRECTORY,
-        FILES, IGNORED_FILES)));
+        FILES, IGNORED_FILES, TRIGGER_NUMBER)));
   }
 
   /**
@@ -292,7 +294,7 @@ public class FilesFoundTriggerTest {
   public void writeToXmlMasterWithAdditionalConfigs() {
     String xml = toXml(trigger(SPEC, masterConfig(), masterConfig()));
     assertThat(xml, is(String.format(XML_MASTER_ADDITIONAL_CONFIGS, SPEC,
-        DIRECTORY, FILES, IGNORED_FILES, DIRECTORY, FILES, IGNORED_FILES)));
+        DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER)));
   }
 
   /**
@@ -302,7 +304,7 @@ public class FilesFoundTriggerTest {
     String xml = toXml(trigger(SPEC, slaveConfig(), slaveConfig()));
     assertThat(xml, is(String.format(XML_SLAVE_ADDITIONAL_CONFIGS, SPEC,
         SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, SLAVE_NODE, DIRECTORY,
-        FILES, IGNORED_FILES)));
+        FILES, IGNORED_FILES, TRIGGER_NUMBER)));
   }
 
   /**
@@ -321,7 +323,7 @@ public class FilesFoundTriggerTest {
   @Test
   public void readFromXmlSlave() {
     FilesFoundTrigger trigger = fromXml(String.format(XML_SLAVE, SPEC,
-        SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES));
+        SLAVE_NODE, DIRECTORY, FILES, IGNORED_FILES, TRIGGER_NUMBER));
     assertThat(String.valueOf(trigger),
         is(String.valueOf(trigger(SPEC, slaveConfig()))));
     assertThat("tabs", getTabs(trigger), not(nullValue()));
@@ -360,7 +362,7 @@ public class FilesFoundTriggerTest {
             + "  <spec>%s</spec>\n"
             + "</hudson.plugins.filesfoundtrigger.FilesFoundTrigger>", SPEC));
     assertThat(String.valueOf(trigger), is(String.valueOf(trigger(SPEC,
-        new FilesFoundTriggerConfig("", "", "", "")))));
+        new FilesFoundTriggerConfig("", "", "", "", "")))));
     assertThat("tabs", getTabs(trigger), not(nullValue()));
   }
 
@@ -424,7 +426,7 @@ public class FilesFoundTriggerTest {
   private FilesFoundTriggerConfig foundConfig() throws IOException {
     folder.newFile("test");
     return new FilesFoundTriggerConfig(MASTER_NODE, folder.getRoot()
-        .getAbsolutePath(), FILES, IGNORED_FILES);
+        .getAbsolutePath(), FILES, IGNORED_FILES, TRIGGER_NUMBER);
   }
 
   /**
@@ -433,7 +435,7 @@ public class FilesFoundTriggerTest {
    * @return a new configuration that will not find files
    */
   private FilesFoundTriggerConfig notFoundConfig() {
-    return new FilesFoundTriggerConfig(MASTER_NODE, "", "", "");
+    return new FilesFoundTriggerConfig(MASTER_NODE, "", "", "", TRIGGER_NUMBER);
   }
 
   /**

--- a/src/test/java/hudson/plugins/filesfoundtrigger/Support.java
+++ b/src/test/java/hudson/plugins/filesfoundtrigger/Support.java
@@ -146,7 +146,7 @@ class Support {
    * @return a new {@link FilesFoundTriggerConfig}
    */
   static FilesFoundTriggerConfig emptyConfig() {
-    return new FilesFoundTriggerConfig("", "", "", "", "");
+    return new FilesFoundTriggerConfig("", "", "", "", "1");
   }
 
   /**

--- a/src/test/java/hudson/plugins/filesfoundtrigger/Support.java
+++ b/src/test/java/hudson/plugins/filesfoundtrigger/Support.java
@@ -25,6 +25,8 @@ package hudson.plugins.filesfoundtrigger;
 
 import hudson.util.XStream2;
 
+import static hudson.plugins.filesfoundtrigger.Support.TRIGGER_NUMBER;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -68,6 +70,10 @@ class Support {
   /**
    */
   static final String IGNORED_FILES = "ignored";
+  
+  /**
+   */
+  static final String TRIGGER_NUMBER = "1";
 
   /**
    */
@@ -84,12 +90,14 @@ class Support {
    *          the pattern of files
    * @param ignoredFiles
    *          the pattern of ignored files
+   * @param triggerNumber
+   *          the minimum number of files to trigger the build
    * @return a new {@link FilesFoundTriggerCause}
    */
   static FilesFoundTriggerCause cause(String node, String directory,
-      String files, String ignoredFiles) {
+      String files, String ignoredFiles, String triggerNumber) {
     return new FilesFoundTriggerCause(config(node, directory, files,
-        ignoredFiles));
+        ignoredFiles, triggerNumber));
   }
 
   /**
@@ -103,11 +111,13 @@ class Support {
    *          the pattern of files
    * @param ignoredFiles
    *          the pattern of ignored files
+   * @param triggerNumber
+   *           the minimum number of found files to trigger the build
    * @return a new {@link FilesFoundTriggerConfig}
    */
   static FilesFoundTriggerConfig config(String node, String directory,
-      String files, String ignoredFiles) {
-    return new FilesFoundTriggerConfig(node, directory, files, ignoredFiles);
+      String files, String ignoredFiles, String triggerNumber) {
+    return new FilesFoundTriggerConfig(node, directory, files, ignoredFiles, triggerNumber);
   }
 
   /**
@@ -117,7 +127,7 @@ class Support {
    */
   static FilesFoundTriggerConfig masterConfig() {
     return new FilesFoundTriggerConfig(MASTER_NODE, DIRECTORY, FILES,
-        IGNORED_FILES);
+        IGNORED_FILES, TRIGGER_NUMBER);
   }
 
   /**
@@ -127,7 +137,7 @@ class Support {
    */
   static FilesFoundTriggerConfig slaveConfig() {
     return new FilesFoundTriggerConfig(SLAVE_NODE, DIRECTORY, FILES,
-        IGNORED_FILES);
+        IGNORED_FILES, TRIGGER_NUMBER);
   }
 
   /**
@@ -136,7 +146,7 @@ class Support {
    * @return a new {@link FilesFoundTriggerConfig}
    */
   static FilesFoundTriggerConfig emptyConfig() {
-    return new FilesFoundTriggerConfig("", "", "", "");
+    return new FilesFoundTriggerConfig("", "", "", "", "");
   }
 
   /**


### PR DESCRIPTION
Hi, I added a feature to allow users to specify the minimum number of found files to trigger the build. 

I create this new feature because I don't want the build to be triggered until *all the files* (not any one of the files)I specify in `Files to find` field are detected.

You may read [the question I posted at stackoverflow](http://stackoverflow.com/questions/42051045/jenkins-build-when-multiple-files-are-found) to get more details.

